### PR TITLE
Update logicApp.json to support pagination

### DIFF
--- a/NestedTemplates/logicApp.json
+++ b/NestedTemplates/logicApp.json
@@ -82,7 +82,7 @@
         "functionAppId": "[concat(resourceGroup().id,'/providers/Microsoft.Web/sites/', parameters('functionAppName'))]"
     },
     "resources": [
-    
+
         {
             "type": "Microsoft.Web/connections",
             "apiVersion": "2016-06-01",
@@ -146,12 +146,6 @@
                             }
                         },
                         "Fetch_Guest_users_from_Microsoft_Graph": {
-                            "runAfter": {
-                                "Initialize_ClientSecret": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "Http",
                             "inputs": {
                                 "authentication": {
                                     "audience": "https://graph.microsoft.com",
@@ -163,10 +157,22 @@
                                 "method": "GET",
                                 "queries": {
                                     "$filter": "userType eq 'Guest'",
-                                    "$select": "id,userPrincipalName, userType,mail, displayName, accountEnabled"
+                                    "$select": "id,userPrincipalName, userType,mail, displayName, accountEnabled",
+                                    "$top": "1"
                                 },
                                 "uri": "https://graph.microsoft.com/v1.0/users"
-                            }
+                            },
+                            "runAfter": {
+                                "Initialize_ClientSecret": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "runtimeConfiguration": {
+                                "paginationPolicy": {
+                                    "minimumItemCount": 100000
+                                }
+                            },
+                            "type": "Http"
                         },
                         "Get_ApplicationID_from_Key_Vault": {
                             "runAfter": {

--- a/NestedTemplates/logicApp.json
+++ b/NestedTemplates/logicApp.json
@@ -16,30 +16,9 @@
                 "description": "Unique name for the Azure Function Web App"
             }
         },
-        "appServicePlanName": {
-            "type" : "string",
-            "defaultValue" : "[concat('plan-', parameters('functionAppName'))]",
-            "metadata": {
-                "description": "Name for the Azure Function Web App App service plan"
-            }
-        },
-        "storageAccountName": {
-            "type" : "string",
-            "defaultValue": "[concat('st','guestreview',substring(uniqueString(resourceGroup().id), 0, 6))]",
-            "metadata": {
-                "description": "Unique Name of the Storage Account"
-            }
-        },
-        "appInsightsName": {
-            "type" : "string",
-            "defaultValue" : "[concat('appi-',parameters('functionAppName'))]",
-            "metadata": {
-                "description": "Name for the Application Insights"
-            }
-        },
         "keyVaultName": {
             "type": "String",
-            "defaultValue" : "[concat('kv-','guestreview-', substring(uniqueString(resourceGroup().id), 0, 6))]",
+            "defaultValue": "[concat('kv-','guestreview-', substring(uniqueString(resourceGroup().id), 0, 6))]",
             "metadata": {
                 "description": "Unique name for the Key Vault"
             }
@@ -47,8 +26,8 @@
         "tenantId": {
             "type": "secureObject",
             "defaultValue": {
-                "secretName":"TenantID",
-                "secretValue":""
+                "secretName": "TenantID",
+                "secretValue": ""
             },
             "metadata": {
                 "description": "Your Azure AD Tenant ID"
@@ -57,7 +36,7 @@
         "applicationId": {
             "type": "secureObject",
             "defaultValue": {
-                "secretName":"ApplicationID",
+                "secretName": "ApplicationID",
                 "secretValue": ""
             },
             "metadata": {
@@ -68,7 +47,7 @@
             "type": "secureObject",
             "defaultValue": {
                 "secretName": "ClientSecret",
-                "secretValue":""
+                "secretValue": ""
             },
             "metadata": {
                 "description": "Client Secret of the App registration"
@@ -77,7 +56,7 @@
     },
     "variables": {
         "office365ConnectionName": "office365",
-        "fetchLastSigninAndManagerFunction" : "FetchLastSigninAndManager",
+        "fetchLastSigninAndManagerFunction": "FetchLastSigninAndManager",
         "updateGuestManagementMetaFunction": "UpdateGuestManagementMeta",
         "functionAppId": "[concat(resourceGroup().id,'/providers/Microsoft.Web/sites/', parameters('functionAppName'))]"
     },
@@ -157,8 +136,7 @@
                                 "method": "GET",
                                 "queries": {
                                     "$filter": "userType eq 'Guest'",
-                                    "$select": "id,userPrincipalName, userType,mail, displayName, accountEnabled",
-                                    "$top": "1"
+                                    "$select": "id,userPrincipalName, userType,mail, displayName, accountEnabled"
                                 },
                                 "uri": "https://graph.microsoft.com/v1.0/users"
                             },


### PR DESCRIPTION
Enabling pagination on the logic app HTTP step (https://docs.microsoft.com/en-us/azure/logic-apps/logic-apps-exceed-default-page-size-with-pagination) supports `@odata.nextlink` attributes to support paging until a maximum of 100'000 results which should be more than enough to retrieve guest users.